### PR TITLE
Make it possible to freely configure lines of rabbitmq-env.conf 

### DIFF
--- a/templates/rabbitmq-env.j2
+++ b/templates/rabbitmq-env.j2
@@ -1,3 +1,3 @@
-{% for k, v in rabbitmq_env_conf.iteritems() %}
-{{ k | upper }}={{ v }}
+{% for config in rabbitmq_env_conf %}
+{{ config }}
 {% endfor %}


### PR DESCRIPTION
As discussed, this resolves #2 by changing the rabbitmq-env.conf template to loop over a list and write it's items as lines into the configuration file.
